### PR TITLE
Update environment.yml and change downloadable csv to PXX values

### DIFF
--- a/environments/environment.yml
+++ b/environments/environment.yml
@@ -1,4 +1,4 @@
-name: env_geothack
+name: env_powerdensity
 
 channels:
   - conda-forge

--- a/environments/environment_geothack.yml
+++ b/environments/environment_geothack.yml
@@ -22,4 +22,6 @@ dependencies:
   - notebook
   - vega_datasets
   - streamlit
+  - xlrd
+  - openpyxl
   - pip

--- a/streamlit/Power-Density_streamlit.py
+++ b/streamlit/Power-Density_streamlit.py
@@ -139,11 +139,12 @@ powerdens_sigma = (np.log(PowerDens_P10)-np.log(PowerDens_P90))/((norm.ppf(1-0.1
 capacity_nu = area_nu + powerdens_nu
 capacity_sigma = ((area_sigma**2)+(powerdens_sigma**2))**0.5
 
-indices = ['area [sqkm]', 'power_density [MWe/sqkm]', 'capacity [MWe]']
-means_std = {'mean': [area_nu, powerdens_nu, capacity_nu],
-            'stdev': [area_sigma, powerdens_sigma, capacity_sigma]}
+indices = ['area [sqkm]', 'power_density [MWe/sqkm]']
+p_values = {'P90': [Area_P90, PowerDens_P90],
+            'P50': [np.exp(area_nu), np.exp(powerdens_nu)],
+            'P10': [Area_P10, PowerDens_P10]}
 
-param_df = pd.DataFrame.from_dict(means_std, orient='index', columns=indices)
+param_df = pd.DataFrame.from_dict(p_values, orient='index', columns=indices)
 
 # Calculate cumulative confidence curve
 prob_df = calculate_cumulative_conf(Area_P90, Area_P10, PowerDens_P90, PowerDens_P10)

--- a/streamlit/Power-Density_streamlit.py
+++ b/streamlit/Power-Density_streamlit.py
@@ -178,8 +178,8 @@ if st.button('Build Confidence-curve CSV for download'):
     tmp_download_link = download_link(prob_df, 'cum_conf_curve.csv', 'CSV built! Click here to download your data!')
     st.markdown(tmp_download_link, unsafe_allow_html=True)
 
-if st.button('Build parameter CSV for download'):
-    tmp_download_link_params = download_link(param_df, 'parameter_values.csv', 'CSV built! Click here to download your data!')
+if st.button('Build input parameter CSV for download'):
+    tmp_download_link_params = download_link(param_df, 'input_parameter_values.csv', 'CSV built! Click here to download your data!')
     st.markdown(tmp_download_link_params, unsafe_allow_html=True)
 
 st.write("") #blank line so space it out

--- a/streamlit/Power-Density_streamlit.py
+++ b/streamlit/Power-Density_streamlit.py
@@ -139,10 +139,10 @@ powerdens_sigma = (np.log(PowerDens_P10)-np.log(PowerDens_P90))/((norm.ppf(1-0.1
 capacity_nu = area_nu + powerdens_nu
 capacity_sigma = ((area_sigma**2)+(powerdens_sigma**2))**0.5
 
-indices = ['area [sqkm]', 'power_density [MWe/sqkm]']
-p_values = {'P90': [Area_P90, PowerDens_P90],
-            'P50': [np.exp(area_nu), np.exp(powerdens_nu)],
-            'P10': [Area_P10, PowerDens_P10]}
+indices = ['area [sqkm]', 'power_density [MWe/sqkm], capacity [MWe]']
+p_values = {'P90': [Area_P90, PowerDens_P90, 'P90_capacity'],
+            'P50': [np.exp(area_nu), np.exp(powerdens_nu), np.exp(capacity_nu)],
+            'P10': [Area_P10, PowerDens_P10, 'P10_capacity']}
 
 param_df = pd.DataFrame.from_dict(p_values, orient='index', columns=indices)
 


### PR DESCRIPTION
Just in case we keep requirements.txt and environment.yml, I went ahead and renamed the environment file to `environment.yml` and updated added libraries for working with excel files. 
I think, we maybe should keep the environment file (for using the app locally etc. and for conda users) and of course also the .txt file, as it is required for the deployed streamlit app.

Related to issue #6 

Edit 2021-07-05:
The downloadable input-parameter csv is now changed. Mean and standard deviation of area, power density and capacity were replaced by the P90, P50, P10 values of area and power density.
